### PR TITLE
chore(ci): add Ruff lint GitHub Action

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,20 @@
+name: CI - Lint
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["chore/add-ci-lint"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: pip install ruff==0.5.6
+      - name: Lint
+        run: ruff check --output-format=github .


### PR DESCRIPTION
This PR adds a minimal GitHub Actions workflow to run Ruff lint on pushes to the feature branch and on pull requests targeting main.

- Uses Python 3.11 on ubuntu-latest
- Installs ruff==0.5.6 and runs `ruff check --output-format=github .`

This should help catch style issues early and keep code quality consistent.